### PR TITLE
No late entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Dungeon Crawl Stone Soup scoreboard keeper for the Crawl Cosplay 3-in-1 website
 ### Install mac/unix
 
  - `composer install`
- - `cp resources/setup/webserver.php webroot`
- - Import `resources/setup/db.sql` into your local database
+ - `cp resources/setup/server.php webroot`
+ - Import `resources/setup/cosplay.sql` into your local database
  - Start local webserver with `resources/bin/local`
 
-The `vendor/bin/local` injects the database credentials. Assumes that the db `cosplay` is available to user `root` with password `root` on `localhost`. Edit if not appropriate.
+The `resources/bin/local` injects the database credentials. Assumes that the db `cosplay` is available to user `root` with password `root` on `localhost`. Edit if not appropriate.
 
 ### Install windows
 

--- a/content/pages/admin/submissions/edit.html.php
+++ b/content/pages/admin/submissions/edit.html.php
@@ -96,13 +96,6 @@ if ($data = $this->request->getPostData()) {
         <br />
         <br />
         <label>
-            <input type="hidden" name="late" value="0" />
-            <input type="checkbox" name="late" value="1" <?=$sub->late?'checked="checked"':''?> />
-            <span>Late Entry?</span>
-        </label>
-        <br />
-        <br />
-        <label>
             <span>Comment</span><br />
             <textarea name="comment" rows="5" cols="100" ><?=$sub->comment?></textarea>
         </label>


### PR DESCRIPTION
Removes the late entry field from the edit submission screen.  

This does not change any schema or queries that display previously added late entries.